### PR TITLE
feat: Make `tmp_name` optional

### DIFF
--- a/src/Type/Upload.php
+++ b/src/Type/Upload.php
@@ -21,7 +21,7 @@ class Upload
      *
      * @var array
      */
-    public static $validationFileKeys = ['name', 'type', 'size', 'tmp_name'];
+    public static $validationFileKeys = ['name', 'type', 'size'];
 
     /**
      * Register the scalar Upload type.
@@ -65,6 +65,12 @@ class Upload
     {
         if (!static::arrayKeysExist($value, static::$validationFileKeys)) {
             throw new UnexpectedValueException('Could not get uploaded file, be sure to conform to GraphQL multipart request specification. Instead got: ' . Utils::printSafe($value));
+        }
+
+        // If not supplied, use the server's temp directory.
+        if(empty($value['tmp_name'])) {
+          $tmp_dir = get_temp_dir();
+          $value['tmp_name'] = $tmp_dir . wp_unique_filename($tmp_dir, $value['name']);
         }
 
         return $value;

--- a/src/Type/Upload.php
+++ b/src/Type/Upload.php
@@ -68,7 +68,7 @@ class Upload
         }
 
         // If not supplied, use the server's temp directory.
-        if(empty($value['tmp_name'])) {
+        if (empty($value['tmp_name'])) {
           $tmp_dir = get_temp_dir();
           $value['tmp_name'] = $tmp_dir . wp_unique_filename($tmp_dir, $value['name']);
         }

--- a/tests/BodyParserTest.php
+++ b/tests/BodyParserTest.php
@@ -7,7 +7,7 @@ use WPGraphQL\Upload\Request\BodyParser;
 
 class BodyParserTest extends \WP_UnitTestCase
 {
-    public function tearDown()
+    public function tearDown() : void
     {
         unset($_SERVER['CONTENT_TYPE'], $_FILES);
     }
@@ -29,7 +29,7 @@ class BodyParserTest extends \WP_UnitTestCase
         ];
 
         $file1 = ['name' => 'image.jpg', 'type' => 'image/jpeg', 'size' => 1455000, 'tmp_name' => '/tmp/random'];
-        $file2 = ['name' => 'foo.txt', 'type' => 'text/plain', 'size' => 945000, 'tmp_name' => '/tmp/random2'];
+        $file2 = ['name' => 'foo.txt', 'type' => 'text/plain', 'size' => 945000]; // test without tmp_name.
         $_FILES = [
             1 => $file1,
             2 => $file2,

--- a/tests/UploadTest.php
+++ b/tests/UploadTest.php
@@ -17,6 +17,16 @@ class UploadTest extends \WP_UnitTestCase
         $this->assertSame($file, $actual);
     }
 
+    public function testCanParseUploadedFileInstanceWithoutTmpName(): void
+    {
+        $file = ['name' => 'image.jpg', 'type' => 'image/jpeg', 'size' => 1455000];
+        $actual = Upload::parseValue($file);
+        $this->assertEquals($file['name'], $actual['name']);
+        $this->assertEquals($file['type'], $actual['type']);
+        $this->assertEquals($file['size'], $actual['size']);
+        $this->assertStringContainsString(get_temp_dir(),$actual['tmp_name']);
+    }
+
     public function testCannotParseNonUploadedFileInstance(): void
     {
         $this->expectException(UnexpectedValueException::class);


### PR DESCRIPTION
## Description
This PR makes the `tmp_name` parameter optional, by using the server's default value when none is provided.

## Rationale
In most browser contexts, it is impossible to get the server's tmp path, making it a major headache to provide it to the headless client, especially when we can just let WordPress [tell us what it should be](https://developer.wordpress.org/reference/functions/get_temp_dir/).

As a result (in JS), your mutation input could be as simple as passing the `File` object directly, no need to extract the properties to a new object.

(PS: I added a `void` return type to `tearDown()` to make the env compatible with PHP8/ phpunit 8.5, but I didnt want to mess with the project composer dependencies in this PR).