### PR TITLE
fix: (CS audit) misc fixes

### DIFF
--- a/src/Request/BodyParser.php
+++ b/src/Request/BodyParser.php
@@ -34,9 +34,9 @@ class BodyParser
      */
     public static function processRequest(array $bodyParams, array $requestContext)
     {
-        $contentType = $_SERVER['CONTENT_TYPE'] ?? null;
+        $contentType = isset($_SERVER['CONTENT_TYPE']) ? sanitize_text_field( wp_unslash( $_SERVER['CONTENT_TYPE'] ) ) : '';
 
-        if ($requestContext['method'] === 'POST' && stripos($contentType, 'multipart/form-data') !== false) {
+        if ('POST' === $requestContext['method'] && stripos($contentType, 'multipart/form-data') !== false) {
             if (empty($bodyParams['map'])) {
                 throw new RequestError('The request must define a `map`');
             }
@@ -49,7 +49,7 @@ class BodyParser
                 return json_decode(stripslashes($json), true);
             };
 
-            $map = $decodeJson($bodyParams['map']);
+            $map    = $decodeJson($bodyParams['map']);
             $result = $decodeJson($bodyParams['operations']);
 
             foreach ($map as $fileKey => $locations) {

--- a/src/Request/BodyParser.php
+++ b/src/Request/BodyParser.php
@@ -18,7 +18,7 @@ class BodyParser
      */
     public static function init()
     {
-        add_filter('graphql_request_data', [__CLASS__, 'processRequest'], 10, 2);
+        add_filter('graphql_request_data', [static::class, 'processRequest'], 10, 2);
     }
 
     /**

--- a/src/Request/BodyParser.php
+++ b/src/Request/BodyParser.php
@@ -41,7 +41,7 @@ class BodyParser
                 throw new RequestError('The request must define a `map`');
             }
 
-            $decodeJson = function ($json) {
+            $decodeJson = static function ($json) {
                 if (!is_string($json)) {
                     return $json;
                 }

--- a/src/Type/Upload.php
+++ b/src/Type/Upload.php
@@ -30,7 +30,11 @@ class Upload
     {
         add_action('graphql_register_types', function ($typeRegistry) {
             $typeRegistry->register_scalar('Upload', [
-                'description'  => 'The `Upload` special type represents a file to be uploaded in the same HTTP request as specified by [graphql-multipart-request-spec](https://github.com/jaydenseric/graphql-multipart-request-spec).',
+                'description'  => sprintf(
+                    // translators: %s is a link to the graphql-multipart-request-spec repo
+                    __( 'The `Upload` special type represents a file to be uploaded in the same HTTP request as specified by [graphql-multipart-request-spec](%s).', 'wp-graphql-upload' ),
+                    'https://github.com/jaydenseric/graphql-multipart-request-spec'
+                ),
                 'serialize'    => function ($value) {
                     return static::serialize($value);
                 },

--- a/src/Type/Upload.php
+++ b/src/Type/Upload.php
@@ -28,20 +28,20 @@ class Upload
      */
     public static function registerType()
     {
-        add_action('graphql_register_types', function ($typeRegistry) {
+        add_action('graphql_register_types', static function ($typeRegistry) {
             $typeRegistry->register_scalar('Upload', [
                 'description'  => sprintf(
                     // translators: %s is a link to the graphql-multipart-request-spec repo
                     __( 'The `Upload` special type represents a file to be uploaded in the same HTTP request as specified by [graphql-multipart-request-spec](%s).', 'wp-graphql-upload' ),
                     'https://github.com/jaydenseric/graphql-multipart-request-spec'
                 ),
-                'serialize'    => function ($value) {
+                'serialize'    => static function ($value) {
                     return static::serialize($value);
                 },
-                'parseValue'   => function ($value) {
+                'parseValue'   => static function ($value) {
                     return static::parseValue($value);
                 },
-                'parseLiteral' => function ($value, array $variables = null) {
+                'parseLiteral' => static function ($value, array $variables = null) {
                     return static::parseLiteral($value);
                 },
             ]);

--- a/src/Type/Upload.php
+++ b/src/Type/Upload.php
@@ -30,11 +30,11 @@ class Upload
     {
         add_action('graphql_register_types', function ($typeRegistry) {
             $typeRegistry->register_scalar('Upload', [
-                'description' => 'The `Upload` special type represents a file to be uploaded in the same HTTP request as specified by [graphql-multipart-request-spec](https://github.com/jaydenseric/graphql-multipart-request-spec).',
-                'serialize' => function ($value) {
+                'description'  => 'The `Upload` special type represents a file to be uploaded in the same HTTP request as specified by [graphql-multipart-request-spec](https://github.com/jaydenseric/graphql-multipart-request-spec).',
+                'serialize'    => function ($value) {
                     return static::serialize($value);
                 },
-                'parseValue' => function ($value) {
+                'parseValue'   => function ($value) {
                     return static::parseValue($value);
                 },
                 'parseLiteral' => function ($value, array $variables = null) {
@@ -78,10 +78,10 @@ class Upload
      *   upload(file: ".......")
      * }
      *
-     * @param GraphQLLanguageASTNode $valueNode
+     * @param \WPGraphQL\Upload\Type\GraphQLLanguageASTNode $valueNode
      * @param array|null $variables
      * @return string
-     * @throws Error
+     * @throws \GraphQL\Error\Error
      */
     public static function parseLiteral($value, array $variables = null)
     {

--- a/wp-graphql-upload.php
+++ b/wp-graphql-upload.php
@@ -23,10 +23,10 @@ namespace WPGraphQL;
 $autoload = __DIR__ . '/vendor/autoload.php';
 
 if (file_exists($autoload)) {
-    require_once($autoload);
+    require_once $autoload;
 } else {
-    require_once(__DIR__ . '/src/Request/BodyParser.php');
-    require_once(__DIR__ . '/src/Type/Upload.php');
+    require_once __DIR__ . '/src/Request/BodyParser.php';
+    require_once __DIR__ . '/src/Type/Upload.php';
 }
 
-require_once(__DIR__ . '/init.php');
+require_once __DIR__ . '/init.php';


### PR DESCRIPTION
This PR fixes several issues and code smells. More specifically:

- 8e99796c0119834aa61d8ffb0f36a2303d7599fd : changes `require_once()` to `require_once`, since its a language construct not a function.
- 55f21b3cde4e5bc5cce984b16cae7efcf7836923 : Updates the PHPDoc types to use fully-qualified Class Names so downstream type hints are correct.
- 6d36b7ddd2f479518052773cab23e4c90f0de042: Sanitizes `$_SERVER['CONTENT_TYPE'`] and prevents a PHP notice if its unset.
- e221a10073a3017c9e4a93ce9dac4aec7010a596: Allows the `Upload` description to be translatable.
- 2d864a37de6dba039734a60a886ed164e42a0f89: Uses the modern `static::class` syntax over `__CLASS__`
- 94a5cecd812279bb67c69c93c3d82971ac26c1ca: Use `static` closures to prevent memory leaks from the parent instance.