### PR TITLE
fix: throw RequestError if file is missing from location

### DIFF
--- a/src/Request/BodyParser.php
+++ b/src/Request/BodyParser.php
@@ -26,6 +26,7 @@ class BodyParser
      * Based on the GraphQL multipart request specification.
      *
      * @see https://github.com/jaydenseric/graphql-multipart-request-spec
+     * @see https://github.com/Ecodev/graphql-upload/blob/73a63038455e5fb5aa6c3f0e41a06208c45e8539/src/UploadMiddleware.php#L27
      *
      * @param array $bodyParams     The parsed body parameters.
      * @param array $requestContext The GraphQL request context.
@@ -62,6 +63,17 @@ class BodyParser
                         }
 
                         $items = &$items[$key];
+                    }
+
+                    // Throw an error if the file wasnt found in the location specified in the map
+                    if (! array_key_exists($fileKey, $_FILES)) {
+                        throw new RequestError(
+                            sprintf(
+                                // translators: %s is the location of the file
+                                __('The uploaded file was not found in the specified location `%s`', 'wp-graphql-upload'),
+                                $location
+                            )
+                        );
                     }
 
                     $items = $_FILES[$fileKey];

--- a/tests/BodyParserTest.php
+++ b/tests/BodyParserTest.php
@@ -81,6 +81,44 @@ class BodyParserTest extends \WP_UnitTestCase
         BodyParser::processRequest([], ['method' => 'POST']);
     }
 
+    public function testMissingFileShouldThrows(): void
+    {
+        $query = '{my query}';
+        $variables = [
+            'test' => 1,
+            'test2' => 2,
+            'uploads' => [
+                0 => null,
+                1 => null,
+            ],
+        ];
+        $map = [
+            1 => ['variables.uploads.0'],
+            2 => ['variables.uploads.1'],
+        ];
+
+        $file1 = ['name' => 'image.jpg', 'type' => 'image/jpeg', 'size' => 1455000, 'tmp_name' => '/tmp/random'];
+        $_FILES = [
+            1 => $file1,
+        ];
+
+        $params = [
+            'operations' => json_encode([
+                'query' => $query,
+                'variables' => $variables,
+                'operation_name' => 'testUpload',
+            ]),
+            'map' => json_encode($map),
+        ];
+
+        $_SERVER['CONTENT_TYPE'] = 'multipart/form-data';
+
+        $this->expectException(RequestError::class);
+        $this->expectExceptionMessage('The uploaded file was not found in the specified location `variables.uploads.1`');
+
+        BodyParser::processRequest($params, ['method' => 'POST']);
+    }
+
     public function testOtherContentTypeShouldNotBeTouched(): void
     {
         $_SERVER['CONTENT_TYPE'] = 'application/json';


### PR DESCRIPTION
This PR fixes `BodyParser::processRequest()` to throw a `RequestError` if the uploaded file is not found on the server.

Additionally, a PHPDoc reference has been added to point to the [code inspiration](https://github.com/Ecodev/graphql-upload/blob/73a63038455e5fb5aa6c3f0e41a06208c45e8539/src/UploadMiddleware.php#L27) for the method.

### References
https://github.com/dre1080/wp-graphql-upload/pull/11#issuecomment-1636557924