### PR TITLE
release: 0.1.5

### DIFF
--- a/src/Request/BodyParser.php
+++ b/src/Request/BodyParser.php
@@ -35,7 +35,7 @@ class BodyParser
      */
     public static function processRequest(array $bodyParams, array $requestContext)
     {
-        $contentType = isset($_SERVER['CONTENT_TYPE']) ? sanitize_text_field( wp_unslash( $_SERVER['CONTENT_TYPE'] ) ) : '';
+        $contentType = isset($_SERVER['CONTENT_TYPE']) ? sanitize_text_field(wp_unslash($_SERVER['CONTENT_TYPE'])) : '';
 
         if ('POST' === $requestContext['method'] && stripos($contentType, 'multipart/form-data') !== false) {
             if (empty($bodyParams['map'])) {

--- a/src/Request/BodyParser.php
+++ b/src/Request/BodyParser.php
@@ -39,7 +39,7 @@ class BodyParser
 
         if ('POST' === $requestContext['method'] && stripos($contentType, 'multipart/form-data') !== false) {
             if (empty($bodyParams['map'])) {
-                throw new RequestError('The request must define a `map`');
+                throw new RequestError(__('The request must define a `map`', 'wp-graphql-upload'));
             }
 
             $decodeJson = static function ($json) {

--- a/src/Type/Upload.php
+++ b/src/Type/Upload.php
@@ -56,7 +56,7 @@ class Upload
      */
     public static function serialize($value)
     {
-        throw new InvariantViolation('`Upload` cannot be serialized');
+        throw new InvariantViolation(__('`Upload` cannot be serialized', 'wp-graphql-upload'));
     }
 
     /**
@@ -68,7 +68,12 @@ class Upload
     public static function parseValue($value)
     {
         if (!static::arrayKeysExist($value, static::$validationFileKeys)) {
-            throw new UnexpectedValueException('Could not get uploaded file, be sure to conform to GraphQL multipart request specification. Instead got: ' . Utils::printSafe($value));
+            throw new UnexpectedValueException(
+                sprintf(
+                    __('Could not get uploaded file, be sure to conform to GraphQL multipart request specification. Instead got: %s', 'wp-graphql-upload'),
+                    Utils::printSafe($value)
+                )
+            );
         }
 
         // If not supplied, use the server's temp directory.
@@ -95,7 +100,13 @@ class Upload
      */
     public static function parseLiteral($value, array $variables = null)
     {
-        throw new Error('`Upload` cannot be hardcoded in query, be sure to conform to GraphQL multipart request specification. Instead got: ' . $value->kind, $value);
+        throw new Error(
+            sprintf(
+                __('`Upload` cannot be hardcoded in query, be sure to conform to GraphQL multipart request specification. Instead got: %s', 'wp-graphql-upload'),
+                $value->kind,
+                $value
+            )
+        );
     }
 
     /**

--- a/src/Type/Upload.php
+++ b/src/Type/Upload.php
@@ -32,7 +32,7 @@ class Upload
             $typeRegistry->register_scalar('Upload', [
                 'description'  => sprintf(
                     // translators: %s is a link to the graphql-multipart-request-spec repo
-                    __( 'The `Upload` special type represents a file to be uploaded in the same HTTP request as specified by [graphql-multipart-request-spec](%s).', 'wp-graphql-upload' ),
+                    __('The `Upload` special type represents a file to be uploaded in the same HTTP request as specified by [graphql-multipart-request-spec](%s).', 'wp-graphql-upload'),
                     'https://github.com/jaydenseric/graphql-multipart-request-spec'
                 ),
                 'serialize'    => static function ($value) {
@@ -73,8 +73,8 @@ class Upload
 
         // If not supplied, use the server's temp directory.
         if (empty($value['tmp_name'])) {
-          $tmp_dir = get_temp_dir();
-          $value['tmp_name'] = $tmp_dir . wp_unique_filename($tmp_dir, $value['name']);
+            $tmp_dir = get_temp_dir();
+            $value['tmp_name'] = $tmp_dir . wp_unique_filename($tmp_dir, $value['name']);
         }
 
         return $value;

--- a/tests/BodyParserTest.php
+++ b/tests/BodyParserTest.php
@@ -7,7 +7,7 @@ use WPGraphQL\Upload\Request\BodyParser;
 
 class BodyParserTest extends \WP_UnitTestCase
 {
-    public function tearDown() : void
+    public function tearDown(): void
     {
         unset($_SERVER['CONTENT_TYPE'], $_FILES);
     }

--- a/tests/UploadTest.php
+++ b/tests/UploadTest.php
@@ -24,7 +24,7 @@ class UploadTest extends \WP_UnitTestCase
         $this->assertEquals($file['name'], $actual['name']);
         $this->assertEquals($file['type'], $actual['type']);
         $this->assertEquals($file['size'], $actual['size']);
-        $this->assertStringContainsString(get_temp_dir(),$actual['tmp_name']);
+        $this->assertStringContainsString(get_temp_dir(), $actual['tmp_name']);
     }
 
     public function testCannotParseNonUploadedFileInstance(): void

--- a/wp-graphql-upload.php
+++ b/wp-graphql-upload.php
@@ -7,7 +7,7 @@
  * or newer.
  * Author: ando
  * Author URI: http://github.com/dre1080
- * Version: 0.1.4
+ * Version: 0.1.5
  * Requires at least: 5.0
  * Tested up to: 6.2.2
  * Requires PHP: 7.1
@@ -17,7 +17,7 @@
  * @package  WPGraphQL\Upload
  * @category WPGraphQL
  * @author   ando
- * @version  0.1.4
+ * @version  0.1.5
  */
 
 namespace WPGraphQL;


### PR DESCRIPTION
This PR bumps the plugin version to 0.1.5.

Additionally, it:
- 82213fafb821b84ef67fa7db4f96bdaf61370274:  lints the codebase with the existing `phpcs` ruleset
- 5274b5b605329f8c73032619e33d444df706e82d: Makes the various errors messages translatable with `__()`

as these changes didnt seem to warrant the overhead of a separate PR.

Once approved + merged, a new GH release should be tagged.